### PR TITLE
Patch: TM-T20III support and nopokedex flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Initial release.
 
 ## [Unreleased]
+
+- Added support for printer Epson TM-T20III via a 'model' parameter.
+- Added 'nopokedex' parameter to skip pokedex QR code generation.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ PaulHoule on Hacker
 News](https://news.ycombinator.com/item?id=44257382).
 
 > [!IMPORTANT]  
-> `taskemon` only supports the Epson TM-T20II thermal printer via USB
+> `taskemon` only supports the Epson TM-T20II and TM-T20III thermal printers via USB
 > right now, and was only tested on macOS Sequoia. Patches or PRs to
 > support other models or networked printers are welcome!
 
@@ -32,7 +32,7 @@ News](https://news.ycombinator.com/item?id=44257382).
 - Prints styled task tickets with owner, category, and task description.
 - Generates a QR code linking to a random Pokémon Pokédex entry, or,
   rarely, a fun surprise.
-- Supports the Epson TM-T20II thermal printer via USB out of the box.
+- Supports the Epson TM-T20II and TM-T20III thermal printers via USB out of the box.
 
 ## Installation
 
@@ -60,10 +60,14 @@ sudo make install
 ```bash
 $ taskemon --help
 Usage of taskemon:
+  -model string
+    	the thermal printer model (TM-T20X-II or TM-T20III) (default: TM-T20X-II)
+  -nopokedex
+    	if set to true, no Pokedex QR code will be included (default: false)
   -owner string
-        the person responsible for the task
+    	the person responsible for the task
   -task string
-        the task description
+    	the task description
 ```
 
 ## Contributing

--- a/main.go
+++ b/main.go
@@ -87,16 +87,6 @@ func main() {
 
 	defer dev.Close()
 
-	// intf := ""
-	// done := ""
-
-	// if dev != nil {
-	// 	intf, done, err := dev.DefaultInterface()
-	// 	_, _, _ = intf, done, err
-	// } else {
-	// 	intf, done, err := altDev.DefaultInterface()
-	// 	_, _, _ = intf, done, err
-	// }
 	intf, done, err := dev.DefaultInterface()
 
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -60,8 +60,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	// fmt.Fprintf(os.Stdout, "Printer Model:  %s\n", *model)
-
 	epsonProductID = 0x0e27
 
 	switch *model {
@@ -72,16 +70,6 @@ func main() {
 		epsonProductID = 0x0e27
 		_ = epsonProductID
 	}
-
-	// if *model == "TM-T20III" {
-	// 	epsonProductID = 0x0e28
-	// 	_ = epsonProductID
-	// } else {
-	// 	epsonProductID = 0x0e27
-	// 	_ = epsonProductID
-	// }
-
-	// fmt.Fprintf(os.Stdout, "Printer Product ID:  %s\n", gousb.ID(epsonProductID))
 
 	ctx := gousb.NewContext()
 	defer ctx.Close()

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ const (
 	epsonVendorID = 0x04b8
 
 	// epsonProductID is the USB product ID for the Epson TM-T20X-II printer.
-	epsonProductID = 0x0e27
+	// epsonProductID = 0x0e27
 
 	// pokedexBaseURL is the base URL for the Pokédex.
 	pokedexBaseURL = "https://www.pokemon.com/us/pokedex/"
@@ -34,10 +34,22 @@ const (
 	numberOfPokemons = 1025
 )
 
+var (
+	epsonProductID int
+)
+
+func Use(vals ...interface{}) {
+	for _, val := range vals {
+		_ = val
+	}
+}
+
 func main() {
 	var (
-		task  = flag.String("task", "", "the task description")
-		owner = flag.String("owner", "", "the person responsible for the task")
+		task      = flag.String("task", "", "the task description")
+		owner     = flag.String("owner", "", "the person responsible for the task")
+		model     = flag.String("model", "TM-T20X-II", "the thermal printer model (TM-T20X-II or TM-T20III)")
+		noPokedex = flag.Bool("nopokedex", false, "if set to true, no Pokedex QR code will be included")
 	)
 
 	flag.Parse()
@@ -48,25 +60,57 @@ func main() {
 		os.Exit(1)
 	}
 
+	// fmt.Fprintf(os.Stdout, "Printer Model:  %s\n", *model)
+
+	epsonProductID = 0x0e27
+
+	switch *model {
+	case "TM-T20III":
+		epsonProductID = 0x0e28
+		_ = epsonProductID
+	case "TM-T20X-II":
+		epsonProductID = 0x0e27
+		_ = epsonProductID
+	}
+
+	// if *model == "TM-T20III" {
+	// 	epsonProductID = 0x0e28
+	// 	_ = epsonProductID
+	// } else {
+	// 	epsonProductID = 0x0e27
+	// 	_ = epsonProductID
+	// }
+
+	// fmt.Fprintf(os.Stdout, "Printer Product ID:  %s\n", gousb.ID(epsonProductID))
+
 	ctx := gousb.NewContext()
 	defer ctx.Close()
 
-	dev, err := ctx.OpenDeviceWithVIDPID(epsonVendorID, epsonProductID)
+	dev, err := ctx.OpenDeviceWithVIDPID(epsonVendorID, gousb.ID(epsonProductID))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: Cannot open USB device: %q\n", err)
-
 		os.Exit(1)
 	}
 
 	if dev == nil {
 		fmt.Fprintln(os.Stderr, "Error: Printer not found. Check USB connection and make sure the printer is turned on.")
-
 		os.Exit(1)
 	}
 
 	defer dev.Close()
 
+	// intf := ""
+	// done := ""
+
+	// if dev != nil {
+	// 	intf, done, err := dev.DefaultInterface()
+	// 	_, _, _ = intf, done, err
+	// } else {
+	// 	intf, done, err := altDev.DefaultInterface()
+	// 	_, _, _ = intf, done, err
+	// }
 	intf, done, err := dev.DefaultInterface()
+
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: Cannot claim interface: %q\n", err)
 
@@ -94,7 +138,9 @@ func main() {
 
 	printer.Bold(true).Size(2, 2).Write(*task + "\n\n")
 
-	printer.QRCode(pokemonRoulette(), true, 4, escpos.QRCodeErrorCorrectionLevelH)
+	if !*noPokedex {
+		printer.QRCode(pokemonRoulette(), true, 4, escpos.QRCodeErrorCorrectionLevelH)
+	}
 
 	printer.LineFeed()
 


### PR DESCRIPTION
What's new:
- Added support for Epson TM-T20III by adding a model parameter. By default if not passed the TM-T20II printer is used.
- Added `nopokedex` parameter to disable Pokedex QR code generation. By default, if not passed the QR code is always generated.